### PR TITLE
WIP: Get the adv_debug_sys working with MiSoC!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "software/unwinder"]
 	path = software/unwinder
 	url = https://github.com/whitequark/libunwind
+[submodule "extcores/mor1kx/adv_debug_sys"]
+	path = extcores/mor1kx/adv_debug_sys
+	url = https://github.com/olofk/adv_debug_sys

--- a/misoclib/cpu/mor1kx.py
+++ b/misoclib/cpu/mor1kx.py
@@ -3,6 +3,49 @@ import os
 from migen.fhdl.std import *
 from migen.bus import wishbone
 
+from migen.genlib.record import Record
+from migen.flow.actor import Sink, Source
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+jtag_layout = [
+    ("tck", 1),
+    ("tdi", 1),
+    ("tdo", 1),
+    ("rst", 1),
+    ("select", 1),
+    ("shift", 1),
+    ("capture", 1),
+    ("update", 1),
+]
+
+class BscanSpartan6(Module):
+    def __init__(self, chain=1):
+        self.jtag = Record(jtag_layout)
+        # * BSCAN_SPARTAN6 outputs except TDI are all synchronous
+        #   to falling TCK edges
+        # * TDO is _synchronized_ to falling edges
+        # * TDI must be sampled on rising edges
+        # * use rising TCK as clock and keep in mind that there is
+        #   always one cycle of latency TDI-to-TDO
+        #self.clk = Signal()
+        # self.specials += Instance("BUFG", i_I=self.clk, o_O=self.jtag.clk)
+        #self.comb += self.jtag.clk.eq(self.clk)
+        self.specials += Instance(
+            "BSCAN_SPARTAN6",
+            p_JTAG_CHAIN=chain,
+            o_SEL=self.jtag.select,
+            o_RESET=self.jtag.rst,
+            o_TDI=self.jtag.tdi,
+            #o_DRCK=self.jtag.drck,
+            o_CAPTURE=self.jtag.capture,
+            o_UPDATE=self.jtag.update,
+            o_SHIFT=self.jtag.shift,
+            #o_RUNTEST=self.jtag.runtest,
+            o_TCK=self.jtag.tck,
+            #o_TMS=self.jtag.tms,
+            i_TDO=self.jtag.tdo,
+        )
+
 
 class MOR1KX(Module):
     def __init__(self, platform, reset_pc):
@@ -11,9 +54,27 @@ class MOR1KX(Module):
         self.interrupt = Signal(32)
 
         ###
+        clk = ClockSignal()
+        rst = ResetSignal()
+        or1k_dbg_rst = Signal()
+        cpu_rst = Signal()
+
+        self.comb += [
+           cpu_rst.eq(rst | or1k_dbg_rst),
+        ]
 
         i_adr_o = Signal(32)
         d_adr_o = Signal(32)
+
+        or1k_dbg_adr_i = Signal(32)
+        or1k_dbg_stb_i = Signal()
+        or1k_dbg_dat_i = Signal(32)
+        or1k_dbg_we_i = Signal()
+        or1k_dbg_dat_o = Signal(32)
+        or1k_dbg_ack_o = Signal()
+        or1k_dbg_stall_i = Signal()
+        or1k_dbg_bp_o = Signal()
+
         self.specials += Instance("mor1kx",
                                   p_FEATURE_INSTRUCTIONCACHE="ENABLED",
                                   p_OPTION_ICACHE_BLOCK_WIDTH=4,
@@ -38,9 +99,11 @@ class MOR1KX(Module):
                                   p_OPTION_RESET_PC=reset_pc,
                                   p_IBUS_WB_TYPE="B3_REGISTERED_FEEDBACK",
                                   p_DBUS_WB_TYPE="B3_REGISTERED_FEEDBACK",
+                                  p_FEATURE_DEBUGUNIT="ENABLED",
+                                  p_OPTION_RF_NUM_SHADOW_GPR=1,
 
-                                  i_clk=ClockSignal(),
-                                  i_rst=ResetSignal(),
+                                  i_clk=clk,
+                                  i_rst=cpu_rst,
 
                                   i_irq_i=self.interrupt,
 
@@ -68,13 +131,112 @@ class MOR1KX(Module):
                                   i_dwbm_dat_i=d.dat_r,
                                   i_dwbm_ack_i=d.ack,
                                   i_dwbm_err_i=d.err,
-                                  i_dwbm_rty_i=0)
+                                  i_dwbm_rty_i=0,
+
+                                  i_du_addr_i=or1k_dbg_adr_i[:16],
+                                  i_du_stb_i=or1k_dbg_stb_i,
+                                  i_du_dat_i=or1k_dbg_dat_i,
+                                  i_du_we_i=or1k_dbg_we_i,
+                                  o_du_dat_o=or1k_dbg_dat_o,
+                                  o_du_ack_o=or1k_dbg_ack_o,
+                                  i_du_stall_i=or1k_dbg_stall_i,
+                                  o_du_stall_o=or1k_dbg_bp_o,
+                                  )
+
+        jtag_tap_tck = Signal()
+        jtag_tap_tdi = Signal()
+        jtag_tap_tdo = Signal()
+        jtag_tap_rst = Signal()
+        jtag_tap_idle = Signal()
+        jtag_tap_capture = Signal()
+        jtag_tap_shift = Signal()
+        jtag_tap_pause = Signal()
+        jtag_tap_update = Signal()
+        jtag_tap_select = Signal()
+
+        dbg_adr_o = Signal(32)
+        self.debug = dbg = wishbone.Interface()
+
+        self.specials += Instance(
+            "adbg_top",
+            i_cpu0_clk_i=clk,
+            o_cpu0_rst_o=or1k_dbg_rst,
+            o_cpu0_addr_o=or1k_dbg_adr_i,
+            o_cpu0_data_o=or1k_dbg_dat_i,
+            o_cpu0_stb_o=or1k_dbg_stb_i,
+            o_cpu0_we_o=or1k_dbg_we_i,
+            i_cpu0_data_i=or1k_dbg_dat_o,
+            i_cpu0_ack_i=or1k_dbg_ack_o,
+            o_cpu0_stall_o=or1k_dbg_stall_i,
+            i_cpu0_bp_i=or1k_dbg_bp_o,
+
+            # TAP interface
+            i_tck_i=jtag_tap_tck,
+            i_tdi_i=jtag_tap_tdi,
+            o_tdo_o=jtag_tap_tdo,
+            i_rst_i=jtag_tap_rst,
+            i_capture_dr_i=jtag_tap_capture,
+            i_shift_dr_i=jtag_tap_shift,
+            i_pause_dr_i=jtag_tap_pause,
+            i_update_dr_i=jtag_tap_update,
+            i_debug_select_i=jtag_tap_select,
+
+            # Wishbone debug master
+            i_wb_clk_i=clk,
+            i_wb_dat_i=dbg.dat_r,
+            i_wb_ack_i=dbg.ack,
+            i_wb_err_i=dbg.err,
+
+            o_wb_adr_o=dbg_adr_o,
+            o_wb_dat_o=dbg.dat_w,
+            o_wb_sel_o=dbg.sel,
+            o_wb_cyc_o=dbg.cyc,
+            o_wb_stb_o=dbg.stb,
+            o_wb_we_o=dbg.we,
+            o_wb_cti_o=dbg.cti,
+            o_wb_bte_o=dbg.bte,
+        )
+
+        self.specials += Instance(
+            "xilinx_internal_jtag",
+            o_tck_o=jtag_tap_tck,
+            i_debug_tdo_i=jtag_tap_tdo,
+            o_tdi_o=jtag_tap_tdi,
+            o_test_logic_reset_o=jtag_tap_rst,
+            o_run_test_idle_o=jtag_tap_idle,
+            o_shift_dr_o=jtag_tap_shift,
+            o_capture_dr_o=jtag_tap_capture,
+            o_pause_dr_o=jtag_tap_pause,
+            o_update_dr_o=jtag_tap_update,
+            o_debug_select_o=jtag_tap_select,
+        )
+
+
+        #bscan = self.submodules.bscan = BscanSpartan6()
+        #self.comb += [
+        #    jtag_tap_tck.eq(bscan.jtag.tck),
+        #    jtag_tap_tdi.eq(bscan.jtag.tdi),
+        #    jtag_tap_tdo.eq(bscan.jtag.tdo),
+        #    jtag_tap_rst.eq(bscan.jtag.rst),
+        #    jtag_tap_capture.eq(bscan.jtag.capture),
+        #    jtag_tap_shift.eq(bscan.jtag.shift),
+        #    jtag_tap_pause.eq(0),
+        #    jtag_tap_update.eq(bscan.jtag.update),
+        #    jtag_tap_select.eq(bscan.jtag.select),
+        #]
 
         self.comb += [
             self.ibus.adr.eq(i_adr_o[2:]),
-            self.dbus.adr.eq(d_adr_o[2:])
+            self.dbus.adr.eq(d_adr_o[2:]),
+            self.debug.adr.eq(dbg_adr_o[2:]),
         ]
 
         # add Verilog sources
         platform.add_source_dir(os.path.join("extcores", "mor1kx", "submodule",
+                                             "rtl", "verilog"))
+        platform.add_source_dir(os.path.join("extcores", "mor1kx", "adv_debug_sys",
+                                             "Hardware", "adv_dbg_if",
+                                             "rtl", "verilog"))
+        platform.add_source_dir(os.path.join("extcores", "mor1kx", "adv_debug_sys",
+                                             "Hardware", "xilinx_internal_jtag",
                                              "rtl", "verilog"))

--- a/misoclib/soc/__init__.py
+++ b/misoclib/soc/__init__.py
@@ -83,6 +83,7 @@ class SoC(Module):
                 raise ValueError("Unsupported CPU type: {}".format(cpu_type))
             self.add_wb_master(self.cpu_or_bridge.ibus)
             self.add_wb_master(self.cpu_or_bridge.dbus)
+            self.add_wb_master(self.cpu_or_bridge.debug)
 
             if integrated_rom_size:
                 self.submodules.rom = wishbone.SRAM(integrated_rom_size, read_only=True)

--- a/software/bios/main.c
+++ b/software/bios/main.c
@@ -556,6 +556,13 @@ int main(int i, char **c)
 	puts("\nMiSoC BIOS   http://m-labs.hk\n"
 	"(c) Copyright 2007-2014 Sebastien Bourdeauducq");
 	printf("Revision %08x built "__DATE__" "__TIME__"\n\n", MSC_GIT_ID);
+#ifdef __lm32__
+	printf("Running on lm32.\n");
+#elif __or1k__
+	printf("Running on or1k.\n");
+#else
+	printf("Unknown architecture.\n");
+#endif
 	crcbios();
 	id_print();
 #ifdef CSR_ETHMAC_BASE


### PR DESCRIPTION
DON'T MERGE!

This actually works, but is horribly hacky. 

```
Debug: 211 9 mpsse.c:363 mpsse_purge(): -
Debug: 212 10 mpsse.c:644 mpsse_loopback_config(): off
Debug: 213 10 mpsse.c:689 mpsse_set_frequency(): target 3000000 Hz
Debug: 214 10 mpsse.c:681 mpsse_rtck_config(): off
Debug: 215 10 mpsse.c:670 mpsse_divide_by_5_config(): off
Debug: 216 10 mpsse.c:650 mpsse_set_divisor(): 9
Debug: 217 10 mpsse.c:713 mpsse_set_frequency(): actually 3000000 Hz
Debug: 218 10 core.c:1600 adapter_khz_to_speed(): convert khz to interface specific speed value
Debug: 219 10 core.c:1603 adapter_khz_to_speed(): have interface set up
Debug: 220 10 mpsse.c:689 mpsse_set_frequency(): target 3000000 Hz
Debug: 221 10 mpsse.c:681 mpsse_rtck_config(): off
Debug: 222 10 mpsse.c:670 mpsse_divide_by_5_config(): off
Debug: 223 10 mpsse.c:650 mpsse_set_divisor(): 9
Debug: 224 10 mpsse.c:713 mpsse_set_frequency(): actually 3000000 Hz
Debug: 225 10 core.c:1600 adapter_khz_to_speed(): convert khz to interface specific speed value
Debug: 226 10 core.c:1603 adapter_khz_to_speed(): have interface set up
Info : 227 10 core.c:1388 adapter_init(): clock speed 3000 kHz
Debug: 228 10 openocd.c:137 handle_init_command(): Debug Adapter init complete
Debug: 229 10 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_transport init
Debug: 230 10 command.c:145 script_debug(): command - ocd_transport ocd_transport init
Debug: 232 10 transport.c:240 handle_transport_init(): handle_transport_init
Debug: 233 10 core.c:731 jtag_add_reset(): SRST line released
Debug: 234 10 core.c:755 jtag_add_reset(): TRST line released
Debug: 235 10 core.c:329 jtag_call_event_callbacks(): jtag event: TAP reset
Debug: 236 10 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_jtag arp_init
Debug: 237 10 command.c:145 script_debug(): command - ocd_jtag ocd_jtag arp_init
Debug: 238 10 core.c:1401 jtag_init_inner(): Init JTAG chain
Debug: 239 10 core.c:329 jtag_call_event_callbacks(): jtag event: TAP reset
Debug: 240 11 core.c:1062 jtag_examine_chain(): DR scan interrogation for IDCODE/BYPASS
Debug: 241 11 core.c:329 jtag_call_event_callbacks(): jtag event: TAP reset
Info : 242 11 core.c:961 jtag_examine_chain_display(): JTAG tap: or1200.cpu tap/device found: 0x44008093 (mfg: 0x049 (Xilinx), part: 0x4008, ver: 0x4)
Debug: 243 11 core.c:1192 jtag_validate_ircapture(): IR capture validation scan
Debug: 244 11 core.c:1250 jtag_validate_ircapture(): or1200.cpu: IR capture 0x35
Debug: 245 11 openocd.c:150 handle_init_command(): Examining targets...
Debug: 246 11 target.c:1501 target_call_event_callbacks(): target event 21 (examine-start)
Debug: 247 11 or1k_tap_xilinx_bscan.c:29 or1k_tap_xilinx_bscan_init(): Initialising Xilinx Internal JTAG TAP
Debug: 248 11 core.c:329 jtag_call_event_callbacks(): jtag event: TAP reset
Info : 249 12 or1k_du_adv.c:198 or1k_adv_jtag_init(): adv debug unit is configured with option ADBG_USE_HISPEED
Info : 250 12 or1k_du_adv.c:202 or1k_adv_jtag_init(): adv debug unit is configured with option ENABLE_JSP_MULTI
Info : 251 12 or1k_du_adv.c:203 or1k_adv_jtag_init(): adv debug unit is configured with option ENABLE_JSP_SERVER
Debug: 252 12 or1k_du_adv.c:211 or1k_adv_jtag_init(): Init done
Debug: 253 12 or1k_du_adv.c:230 adbg_select_module(): Select module: CPU0
Debug: 254 12 target.c:1501 target_call_event_callbacks(): target event 22 (examine-end)
Debug: 255 12 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_flash init
Debug: 256 12 command.c:145 script_debug(): command - ocd_flash ocd_flash init
Debug: 258 12 tcl.c:1067 handle_flash_init_command(): Initializing flash devices...
Debug: 259 12 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_mflash init
Debug: 260 12 command.c:145 script_debug(): command - ocd_mflash ocd_mflash init
Debug: 262 13 mflash.c:1379 handle_mflash_init_command(): Initializing mflash devices...
Debug: 263 13 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_nand init
Debug: 264 13 command.c:145 script_debug(): command - ocd_nand ocd_nand init
Debug: 266 13 tcl.c:497 handle_nand_init_command(): Initializing NAND devices...
Debug: 267 13 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_pld init
Debug: 268 13 command.c:145 script_debug(): command - ocd_pld ocd_pld init
Debug: 270 13 pld.c:207 handle_pld_init_command(): Initializing PLDs...
Debug: 271 13 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_echo Halting processor
Debug: 272 13 command.c:145 script_debug(): command - echo ocd_echo Halting processor
User : 274 14 command.c:764 jim_echo(): Halting processor
Debug: 275 14 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_halt
Debug: 276 14 command.c:145 script_debug(): command - halt ocd_halt
Debug: 278 14 target.c:2806 handle_halt_command(): -
Debug: 279 14 or1k.c:579 or1k_halt(): target->state: running
Debug: 280 14 or1k_du_adv.c:313 adbg_ctrl_write(): Write control register 0: 0x00000001
Debug: 281 15 or1k.c:554 or1k_debug_entry(): -
Debug: 282 15 or1k.c:344 or1k_save_context(): -
Debug: 283 15 or1k.c:319 or1k_jtag_read_regs(): -
Debug: 284 15 or1k_du_adv.c:450 adbg_wb_burst_read(): Doing burst read, word size 4, word count 32, start address 0x00000400
Debug: 285 15 or1k_du_adv.c:547 adbg_wb_burst_read(): CRC OK!
Debug: 286 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 287 15 or1k.c:423 or1k_read_core_reg(): Read core reg 0 value 0x00000000
Debug: 288 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 289 15 or1k.c:423 or1k_read_core_reg(): Read core reg 1 value 0x00000000
Debug: 290 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 291 15 or1k.c:423 or1k_read_core_reg(): Read core reg 2 value 0x00000000
Debug: 292 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 293 15 or1k.c:423 or1k_read_core_reg(): Read core reg 3 value 0x00000000
Debug: 294 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 295 15 or1k.c:423 or1k_read_core_reg(): Read core reg 4 value 0x00000000
Debug: 296 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 297 15 or1k.c:423 or1k_read_core_reg(): Read core reg 5 value 0x00000000
Debug: 298 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 299 15 or1k.c:423 or1k_read_core_reg(): Read core reg 6 value 0x00000015
Debug: 300 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 301 15 or1k.c:423 or1k_read_core_reg(): Read core reg 7 value 0x10000078
Debug: 302 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 303 15 or1k.c:423 or1k_read_core_reg(): Read core reg 8 value 0x00000000
Debug: 304 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 305 15 or1k.c:423 or1k_read_core_reg(): Read core reg 9 value 0x40002ee0
Debug: 306 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 307 15 or1k.c:423 or1k_read_core_reg(): Read core reg 10 value 0x00000100
Debug: 308 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 309 15 or1k.c:423 or1k_read_core_reg(): Read core reg 11 value 0x00000000
Debug: 310 15 or1k.c:415 or1k_read_core_reg(): -
Debug: 311 15 or1k.c:423 or1k_read_core_reg(): Read core reg 12 value 0x80108010
Debug: 312 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 313 16 or1k.c:423 or1k_read_core_reg(): Read core reg 13 value 0x0000002c
Debug: 314 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 315 16 or1k.c:423 or1k_read_core_reg(): Read core reg 14 value 0x00000231
Debug: 316 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 317 16 or1k.c:423 or1k_read_core_reg(): Read core reg 15 value 0x0000003c
Debug: 318 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 319 16 or1k.c:423 or1k_read_core_reg(): Read core reg 16 value 0x00000000
Debug: 320 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 321 16 or1k.c:423 or1k_read_core_reg(): Read core reg 17 value 0x10000210
Debug: 322 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 323 16 or1k.c:423 or1k_read_core_reg(): Read core reg 18 value 0x00000231
Debug: 324 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 325 16 or1k.c:423 or1k_read_core_reg(): Read core reg 19 value 0x00000001
Debug: 326 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 327 16 or1k.c:423 or1k_read_core_reg(): Read core reg 20 value 0x10000060
Debug: 328 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 329 16 or1k.c:423 or1k_read_core_reg(): Read core reg 21 value 0x00000040
Debug: 330 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 331 16 or1k.c:423 or1k_read_core_reg(): Read core reg 22 value 0x1000005c
Debug: 332 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 333 16 or1k.c:423 or1k_read_core_reg(): Read core reg 23 value 0x00000000
Debug: 334 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 335 16 or1k.c:423 or1k_read_core_reg(): Read core reg 24 value 0x00000000
Debug: 336 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 337 16 or1k.c:423 or1k_read_core_reg(): Read core reg 25 value 0x00000000
Debug: 338 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 339 16 or1k.c:423 or1k_read_core_reg(): Read core reg 26 value 0x00000000
Debug: 340 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 341 16 or1k.c:423 or1k_read_core_reg(): Read core reg 27 value 0x00000000
Debug: 342 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 343 16 or1k.c:423 or1k_read_core_reg(): Read core reg 28 value 0x00000000
Debug: 344 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 345 16 or1k.c:423 or1k_read_core_reg(): Read core reg 29 value 0x00000000
Debug: 346 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 347 16 or1k.c:423 or1k_read_core_reg(): Read core reg 30 value 0x00000000
Debug: 348 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 349 16 or1k.c:423 or1k_read_core_reg(): Read core reg 31 value 0x00000000
Debug: 350 16 or1k_du_adv.c:450 adbg_wb_burst_read(): Doing burst read, word size 4, word count 1, start address 0x00000012
Debug: 351 16 or1k_du_adv.c:547 adbg_wb_burst_read(): CRC OK!
Debug: 352 16 or1k.c:415 or1k_read_core_reg(): -
Debug: 353 16 or1k.c:423 or1k_read_core_reg(): Read core reg 32 value 0x40002e2c
Debug: 354 16 or1k_du_adv.c:450 adbg_wb_burst_read(): Doing burst read, word size 4, word count 1, start address 0x00000010
Debug: 355 17 or1k_du_adv.c:547 adbg_wb_burst_read(): CRC OK!
Debug: 356 17 or1k.c:415 or1k_read_core_reg(): -
Debug: 357 17 or1k.c:423 or1k_read_core_reg(): Read core reg 33 value 0x40002e30
Debug: 358 17 or1k_du_adv.c:450 adbg_wb_burst_read(): Doing burst read, word size 4, word count 1, start address 0x00000011
Debug: 359 17 or1k_du_adv.c:547 adbg_wb_burst_read(): CRC OK!
Debug: 360 17 or1k.c:415 or1k_read_core_reg(): -
Debug: 361 17 or1k.c:423 or1k_read_core_reg(): Read core reg 34 value 0x0000821d
Debug: 362 17 target.c:1501 target_call_event_callbacks(): target event 0 (gdb-halt)
Debug: 363 17 target.c:1501 target_call_event_callbacks(): target event 1 (halted)
User : 364 17 target.c:1936 target_arch_state(): or1200.cpu: target state: halted
Debug: 365 17 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_target names
Debug: 366 17 command.c:145 script_debug(): command - ocd_target ocd_target names
Debug: 367 17 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_or1200.cpu cget -endian
Debug: 368 17 command.c:145 script_debug(): command - ocd_or1200.cpu ocd_or1200.cpu cget -endian
Debug: 369 17 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_or1200.cpu cget -type
Debug: 370 17 command.c:145 script_debug(): command - ocd_or1200.cpu ocd_or1200.cpu cget -type
Chip is or1200.cpu, Endian: big, type: or1k
Target ready...
Debug: 371 17 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_init
Debug: 372 17 command.c:145 script_debug(): command - init ocd_init
Debug: 374 18 command.c:145 script_debug(): command - ocd_command ocd_command type ocd_init
Debug: 375 18 command.c:145 script_debug(): command - init ocd_init
```
